### PR TITLE
Restrict eraser to brush strokes

### DIFF
--- a/README.md
+++ b/README.md
@@ -927,7 +927,7 @@
           'draw-circle':'Drag from center.',
           'draw-bucket':'Click one; or drag a box to recolor everything it touches.',
           'draw-crop':'Two-step: first choose mask; second choose keep-area (deletes ring).',
-          'draw-erase':'Click deletes one; or drag a box to delete all it touches.'
+          'draw-erase':'Click deletes brush strokes; drag a box to delete all strokes it touches.'
         };
         add(`<p class="note">${tips[state.tool]}</p>`);
       }
@@ -1372,8 +1372,13 @@
       }
       if(state.tool==='draw-erase'){
         const hit=hitTest(world,'draw');
-        if(hit){ currPage().objects = currPage().objects.filter(o=>o.id!==hit.id); pushHistory(); endInteractions(false); }
-        else { state.marquee={x:state.mouse.x,y:state.mouse.y,w:0,h:0, erase:true}; }
+        if(hit && hit.kind==='draw'){
+          currPage().objects = currPage().objects.filter(o=>o.id!==hit.id);
+          pushHistory();
+          endInteractions(false);
+        } else if(!hit){
+          state.marquee={x:state.mouse.x,y:state.mouse.y,w:0,h:0, erase:true};
+        }
         return;
       }
       if(state.tool==='draw-brush'){


### PR DESCRIPTION
## Summary
- Limit eraser tool so it only removes brush strokes
- Clarify eraser usage in on-screen tips

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b9d3cd60832b9c64a31bfa2c7076